### PR TITLE
[misc] Updated meta, removed exec perm from uwsgi.ini, allow customizing uwsgi command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Below are listed all the variables you can customize
     openwisp2_wireguard_flask_port: 8081
     # Host where Flask endpoint is run
     openwisp2_wireguard_flask_host: 0.0.0.0
+    # Command used to run uwsgi from supervisor
+    openwisp2_wireguard_uwsgi_command: "{{ openwisp2_wireguard_path }}/env/bin/uwsgi uwsgi.ini"
 
     # specify path to a valid SSL certificate and key
     # (a self-signed SSL cert will be generated if omitted)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ openwisp2_wireguard_flask_key: false
 openwisp2_wireguard_flask_port: 8081
 openwisp2_wireguard_flask_host: 0.0.0.0
 openwisp2_wireguard_flask_endpoint: "/trigger-update"
+openwisp2_wireguard_uwsgi_command: "{{ openwisp2_wireguard_path }}/env/bin/uwsgi uwsgi.ini"
 
 openwisp2_wireguard_vxlan_ipv4_method: link-local
 openwisp2_wireguard_vxlan_ipv6_method: link-local

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 
 galaxy_info:
+  role_name: wireguard_openwisp
+  namespace: openwisp
   author: Gagan Deep
   company: OpenWISP
   description: Role to install OpenWISP's Wireguard Updater
@@ -22,3 +24,5 @@ galaxy_info:
   galaxy_tags:
     - system
     - networking
+    - wireguard
+    - openwisp

--- a/tasks/uwsgi.yml
+++ b/tasks/uwsgi.yml
@@ -29,5 +29,5 @@
     src: flask/uwsgi.ini
     dest: "{{ openwisp2_wireguard_path }}/uwsgi.ini"
     group: "{{ openwisp_group }}"
-    mode: 0754
+    mode: 0644
   tags: [flask]

--- a/templates/supervisor/vpn_updater.j2
+++ b/templates/supervisor/vpn_updater.j2
@@ -1,7 +1,7 @@
 [program:openwisp-flask-vpn-updater-{{ openwisp2_wireguard_vpn_uuid }}]
 user=root
 directory={{ openwisp2_wireguard_path }}
-command={{ openwisp2_wireguard_path }}/env/bin/uwsgi uwsgi.ini
+command={{ openwisp2_wireguard_uwsgi_command }}
 autostart=true
 autorestart=true
 stopsignal=INT


### PR DESCRIPTION
Updated meta, removed exec perm from uwsgi.ini, allow customizing uwsgi command.

I needed to allow customizing the uwsgi command because I had to run uwsgi with:

```
authbind --deep {{ openwisp2_wireguard_path }}/env/bin/uwsgi uwsgi.ini
```

I configured `authbind` to allow the `openwisp` user to bind to port 443, which is the only available open port on this server.