### PR TITLE
[ci] Fix openwisp-utils install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
 
       - name: Install python dependencies
         run: |
-          pip install molecule[docker,ansible] yamllint ansible-lint docker openwisp-utils[qa]
+          pip install -U pip wheel setuptools
+          pip install molecule[docker,ansible] yamllint ansible-lint docker
+          pip install openwisp-utils[qa]
 
       - name: Install Ansible Galaxy dependencies
         run: ansible-galaxy collection install "community.general:>=3.6.0"

--- a/molecule/resources/converge.yml
+++ b/molecule/resources/converge.yml
@@ -4,6 +4,6 @@
   hosts: all
   become: true
   roles:
-    - role: ansible-wireguard-openwisp
+    - role: openwisp.wireguard_openwisp
   vars_files:
     - ../vars/main.yml


### PR DESCRIPTION
The CI was installing `openwisp-utils 0.4.5` for some reason https://github.com/openwisp/ansible-wireguard-openwisp/actions/runs/3957847245/jobs/6778708622#step:4:245