### PR TITLE
[fix] Remove deprecated command args

### DIFF
--- a/tasks/uwsgi.yml
+++ b/tasks/uwsgi.yml
@@ -19,8 +19,6 @@
     -keyout {{ openwisp2_wireguard_ssl_key }} \
     -out {{ openwisp2_wireguard_ssl_cert }} \
     -extensions v3_ca creates={{ openwisp2_wireguard_ssl_cert }}
-  args:
-    warn: false
   tags: [ssl]
 
 - name: uwsgi.ini

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -85,8 +85,6 @@
       block:
         - name: Enable PowerTools (CentOS 8)
           command: yum config-manager --set-enabled powertools
-          args:
-            warn: false
           when: ansible_distribution == 'CentOS'
         - name: Enable cloudready-builder (RHEL 8)
           command: subscription-manager repos --enable codeready-builder-for-rhel-8-$(arch)-rpms


### PR DESCRIPTION
I had problems installing the openwisp.wireguard_openwisp role.
Since updating the openwisp role a few days ago solved a similar problem, I applied similar changes  (https://github.com/openwisp/ansible-openwisp2/pull/419)to this role and managed to run it.

do with it what you like :)