### PR TITLE
Addresses my comments in issue #36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,5 @@ dmypy.json
 
 # Code editor
 .vscode/
-
+*.log
+*.log.ansi

--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ Below are listed all the variables you can customize
     openwisp2_wireguard_python: python2.7
     # virtualenv command for your remote distribution, usually set automcatically
     openwisp2_wireguard_virtualenv_command: "virtualenv"
-
+    # Set this to INFO, ERROR, or DEBUG these are the ONLY LEVELS SUPPORTED INFO is very chatty but informative
+    openwisp2_wireguard_update_wireguard_log_level: "INFO"
     # Sets the ipv4.method of VXLAN connection, defaults to "link-local"
     openwisp2_wireguard_vxlan_ipv4_method: disabled
     openwisp2_wireguard_vxlan_ipv6_method: disabled

--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ Below are listed all the variables you can customize
     # Sets the ipv4.method of VXLAN connection, defaults to "link-local"
     openwisp2_wireguard_vxlan_ipv4_method: disabled
     openwisp2_wireguard_vxlan_ipv6_method: disabled
+    #set the log level for flask logging
+    openwisp2_wirguard_flask_logging_level: "INFO"
+    #where to store the flask logs
+    openwisp2_wirguard_flask_logging_file: "/log/openwisp-flask-vpntrigger.log"
+    #How big should we let the logfile grow before we rotate?
+    openwisp2_wirguard_flask_logging_file_size: "104857600" #100MB
+    #How many files should we keep before we overwrite?
+    openwisp2_wirguard_flask_logging_file_count: "10"
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ Below are listed all the variables you can customize
     # Sets the ipv4.method of VXLAN connection, defaults to "link-local"
     openwisp2_wireguard_vxlan_ipv4_method: disabled
     openwisp2_wireguard_vxlan_ipv6_method: disabled
+    #set the logging level for the flask application
+    openwisp2_wirguard_flask_logging_level: "INFO"
+    #sets the log location for the flash logger
+    openwisp2_wirguard_flask_logging_file: "/log/openwisp-flask-vpntrigger.log"
+    #sets the filesize for the flask logger before rotating
+    openwisp2_wirguard_flask_logging_file_size: "104857600" #100MB
+    #sets the maximum number of logs to keep before rolling over
+    openwisp2_wirguard_flask_logging_file_count: "10"
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -211,14 +211,6 @@ Below are listed all the variables you can customize
     # Sets the ipv4.method of VXLAN connection, defaults to "link-local"
     openwisp2_wireguard_vxlan_ipv4_method: disabled
     openwisp2_wireguard_vxlan_ipv6_method: disabled
-    #set the logging level for the flask application
-    openwisp2_wirguard_flask_logging_level: "INFO"
-    #sets the log location for the flash logger
-    openwisp2_wirguard_flask_logging_file: "/log/openwisp-flask-vpntrigger.log"
-    #sets the filesize for the flask logger before rotating
-    openwisp2_wirguard_flask_logging_file_size: "104857600" #100MB
-    #sets the maximum number of logs to keep before rolling over
-    openwisp2_wirguard_flask_logging_file_count: "10"
 ```
 
 ## Contributing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ openwisp2_wireguard_controller_url: "https://{{ inventory_hostname }}"
 openwisp2_wireguard_vpn_uuid: false
 openwisp2_wireguard_vpn_key: false
 openwisp2_wirguard_flask_logging_level: "INFO"
-openwisp2_wirguard_flask_logging_file: "/log/openwisp-flask-vpntrigger.log"
+openwisp2_wirguard_flask_logging_file: "/log/openwisp-flash-vpntrigger.log"
 openwisp2_wirguard_flask_logging_file_size: "104857600" #100MB
 openwisp2_wirguard_flask_logging_file_count: "10"
 openwisp2_wireguard_flask_key: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,12 +8,15 @@ openwisp2_wireguard_curl_insecure: false
 openwisp2_wireguard_controller_url: "https://{{ inventory_hostname }}"
 openwisp2_wireguard_vpn_uuid: false
 openwisp2_wireguard_vpn_key: false
+openwisp2_wirguard_flask_logging_level: "INFO"
+openwisp2_wirguard_flask_logging_file: "/log/openwisp-flash-vpntrigger.log"
+openwisp2_wirguard_flask_logging_file_size: "104857600" #100MB
+openwisp2_wirguard_flask_logging_file_count: "10"
 openwisp2_wireguard_flask_key: false
 openwisp2_wireguard_flask_port: 8081
 openwisp2_wireguard_flask_host: 0.0.0.0
 openwisp2_wireguard_flask_endpoint: "/trigger-update"
 openwisp2_wireguard_uwsgi_command: "{{ openwisp2_wireguard_path }}/env/bin/uwsgi uwsgi.ini"
-
 openwisp2_wireguard_vxlan_ipv4_method: link-local
 openwisp2_wireguard_vxlan_ipv6_method: link-local
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ openwisp2_wireguard_controller_url: "https://{{ inventory_hostname }}"
 openwisp2_wireguard_vpn_uuid: false
 openwisp2_wireguard_vpn_key: false
 openwisp2_wirguard_flask_logging_level: "INFO"
-openwisp2_wirguard_flask_logging_file: "/log/openwisp-flash-vpntrigger.log"
+openwisp2_wirguard_flask_logging_file: "/log/openwisp-flask-vpntrigger.log"
 openwisp2_wirguard_flask_logging_file_size: "104857600" #100MB
 openwisp2_wirguard_flask_logging_file_count: "10"
 openwisp2_wireguard_flask_key: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 openwisp2_wireguard_python: python3
 openwisp2_wireguard_virtualenv_command: "virtualenv"
-
+openwisp2_wireguard_update_wireguard_log_level: "INFO"
 openwisp2_wireguard_path: "/opt/wireguard-openwisp"
 openwisp2_wireguard_curl_insecure: false
 openwisp2_wireguard_controller_url: "https://{{ inventory_hostname }}"

--- a/files/sudoers.d/openwisp
+++ b/files/sudoers.d/openwisp
@@ -1,1 +1,1 @@
-%openwisp ALL = NOPASSWD: /usr/bin/wg-quick, /usr/bin/wg, /usr/bin/nmcli, /usr/bin/ip, /usr/sbin/bridge
+%openwisp ALL = NOPASSWD: /usr/bin/wg-quick, /usr/bin/wg, /usr/bin/nmcli, /usr/bin/ip, /usr/sbin/bridge, /bin/chmod 664 {{ openwisp2_wireguard_path }}/vpn_updater.log, /bin/chgrp openwisp {{ openwisp2_wireguard_path }}/vpn_updater.log

--- a/tasks/flask.yml
+++ b/tasks/flask.yml
@@ -8,6 +8,14 @@
     mode: 0770
   tags: [wireguard]
 
+- name: Create Wireguard log directory
+  file:
+    path: "{{ openwisp2_wireguard_path }}/log"
+    state: directory
+    group: "{{ openwisp_group }}"
+    mode: 0770
+  tags: [wireguard]
+
 - name: update_wireguard.sh
   template:
     src: update_scripts/update_wireguard.sh.j2

--- a/tasks/flask.yml
+++ b/tasks/flask.yml
@@ -80,7 +80,7 @@
     day: "*"
     hour: "*"
     minute: "*/5"
-    job: "{{ openwisp2_wireguard_path }}/update_wireguard.sh check_config"
+    job: "sudo /bin/chgrp openwisp {{ openwisp2_wireguard_path }}/vpn_updater.log &&  sudo /bin/chmod 664 {{ openwisp2_wireguard_path }}/vpn_updater.log && {{ openwisp2_wireguard_path }}/update_wireguard.sh check_config"
     state: present
     user: "{{ openwisp_user }}"
   tags: [wireguard, updater_script]

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -28,6 +28,7 @@
     name:
       - "Flask~=2.0.3"
       - "uwsgi~=2.0.19"
+      - "werkzeug"  # Optionally specify a version
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_wireguard_python }}"

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -28,7 +28,8 @@
     name:
       - "Flask~=2.0.3"
       - "uwsgi~=2.0.19"
-    state: latest
+      - "Werkzeug>=2.0, <3.0"
+    state: present
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_wireguard_python }}"
     virtualenv_site_packages: true

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -28,7 +28,6 @@
     name:
       - "Flask~=2.0.3"
       - "uwsgi~=2.0.19"
-      - "werkzeug"  # Optionally specify a version
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_wireguard_python }}"

--- a/templates/flask/vpn_updater.py
+++ b/templates/flask/vpn_updater.py
@@ -1,9 +1,7 @@
 import subprocess
 import logging
+import hmac
 from logging.handlers import RotatingFileHandler
-from werkzeug.security import safe_str_cmp
-
-
 from flask import Flask, Response, request
 
 app = Flask(__name__)
@@ -12,13 +10,16 @@ KEY = '{{ openwisp2_wireguard_flask_key }}'
 UPDATER_SCRIPTS = [
     '{{ openwisp2_wireguard_path }}/update_wireguard.sh check_config',
 ]
-ALLOWED_SCRIPTS = ["update_wireguard.sh check_config"]
+ALLOWED_SCRIPTS = ['{{ openwisp2_wireguard_path }}/update_wireguard.sh check_config']
 
-
-file_handler = RotatingFileHandler('{{ openwisp2_wireguard_path }}/log/openwisp-vpnupdater.log', maxBytes=104857600, backupCount=10)
+file_handler = RotatingFileHandler('{{ openwisp2_wireguard_path }}{{openwisp2_wirguard_flask_logging_file}}', maxBytes={{openwisp2_wirguard_flask_logging_file_size}}, backupCount={{openwisp2_wirguard_flask_logging_file_count}})
 file_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'))
-file_handler.setLevel(logging.INFO)
+#file_handler.setLevel(logging.INFO)
+file_handler.setLevel(logging.{{openwisp2_wirguard_flask_logging_level}})
+app.logger.setLevel(logging.{{openwisp2_wirguard_flask_logging_level}})
 app.logger.addHandler(file_handler)
+#app.logger.propagate = False
+app.logger.info("Starting the Flask application")
 
 def is_script_allowed(script):
     return script in ALLOWED_SCRIPTS
@@ -37,12 +38,14 @@ def _exec_command(command):
         raise subprocess.SubprocessError()
 
 
-@app.route('{{ openwisp2_wireguard_flask_endpoint }}', methods=['POST'])
+@app.route('/trigger-update', methods=['POST'])
 def update_vpn_config():
     app.logger.info("Received request to update VPN config")
+    print("Received request to update VPN config")
     #changed this so we can do input validation and prevent timing hacks
     provided_key = request.args.get('key')
-    if not provided_key or not safe_str_cmp(provided_key, KEY):
+
+    if not provided_key or not hmac.compare_digest(provided_key, KEY):
         #make sure we log attempts to get through with an invalid key.
         client_info = {
             'ip_address': request.remote_addr,
@@ -56,10 +59,20 @@ def update_vpn_config():
         try:
             #make sure the called scripted is what we expect it to be and if it isn't then exit unauthorized
             if not is_script_allowed(script):
-                app.logger.error("Unauthorized script access attempt: %s", script)
+                client_info = {
+                    'ip_address': request.remote_addr,
+                    'user_agent': request.user_agent.string,
+                    'http_method': request.method
+                }
+                app.logger.error("Unauthorized script access attempt: %s Client info: %s", script, client_info)
                 return Response(status=403)
             _exec_command(script)
-            app.logger.info("Script executed successfully: %s", script)
+            client_info = {
+                'ip_address': request.remote_addr,
+                'user_agent': request.user_agent.string,
+                'http_method': request.method
+            }
+            app.logger.info("Script executed successfully: %s Client info: %s", script, client_info)
         except subprocess.SubprocessError:
             app.logger.error("Script execution failed: %s", script)
             return Response(status=500)
@@ -73,28 +86,28 @@ from flask import Flask, Response
 
 @app.after_request
 def set_csp(response):
-    response.headers["Content-Security-Policy"] = "default-src 'self'"
-    return response
+   response.headers["Content-Security-Policy"] = "default-src 'self'"
+   return response
 @app.after_request
 def set_x_frame_options(response):
-    response.headers["X-Frame-Options"] = "SAMEORIGIN"
-    return response
+   response.headers["X-Frame-Options"] = "SAMEORIGIN"
+   return response
 @app.after_request
 def set_x_content_type_options(response):
-    response.headers["X-Content-Type-Options"] = "nosniff"
-    return response
+   response.headers["X-Content-Type-Options"] = "nosniff"
+   return response
 @app.after_request
 def set_hsts(response):
-    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
-    return response
+   response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+   return response
 @app.after_request
 def set_x_xss_protection(response):
-    response.headers["X-XSS-Protection"] = "1; mode=block"
-    return response
+   response.headers["X-XSS-Protection"] = "1; mode=block"
+   return response
 @app.after_request
 def set_referrer_policy(response):
-    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    return response
+   response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+   return response
 
 
 if __name__ == '__main__':

--- a/templates/flask/vpn_updater.py
+++ b/templates/flask/vpn_updater.py
@@ -38,7 +38,7 @@ def _exec_command(command):
         raise subprocess.SubprocessError()
 
 
-@app.route('/trigger-update', methods=['POST'])
+@app.route('{{ openwisp2_wireguard_flask_endpoint }}', methods=['POST'])
 def update_vpn_config():
     app.logger.info("Received request to update VPN config")
     print("Received request to update VPN config")
@@ -82,7 +82,6 @@ def update_vpn_config():
 def handle_500_error(exception):
     app.logger.error("An internal error occurred: %s", str(exception))
     return Response(status=500)
-from flask import Flask, Response
 
 @app.after_request
 def set_csp(response):

--- a/templates/flask/vpn_updater.py
+++ b/templates/flask/vpn_updater.py
@@ -27,15 +27,13 @@ def is_script_allowed(script):
 def _exec_command(command):
     process = subprocess.Popen(
         command.split(' '),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
         close_fds=True,
     )
-    stdout, stderr = process.communicate()
     exit_code = process.wait(timeout=10)
     if exit_code != 0:
-        app.logger.error("Script execution failed: %s, Error: %s", command, stderr.decode('utf-8'))
+        app.logger.error("Script execution failed: %s", command)
         raise subprocess.SubprocessError()
+
 
 
 @app.route('{{ openwisp2_wireguard_flask_endpoint }}', methods=['POST'])
@@ -73,7 +71,7 @@ def update_vpn_config():
             }
             app.logger.info("Script executed successfully: %s Client info: %s", script, client_info)
         except subprocess.SubprocessError:
-            app.logger.error("Script execution failed: %s", script)
+            app.logger.error("Script execution failed: %s Please check the uswgi log at {{ openwisp2_wireguard_path }}/vpn_updater.log", script )
             return Response(status=500)
     return Response(status=200)
 

--- a/templates/flask/vpn_updater.py
+++ b/templates/flask/vpn_updater.py
@@ -1,4 +1,8 @@
 import subprocess
+import logging
+from logging.handlers import RotatingFileHandler
+from werkzeug.security import safe_str_cmp
+
 
 from flask import Flask, Response, request
 
@@ -8,7 +12,16 @@ KEY = '{{ openwisp2_wireguard_flask_key }}'
 UPDATER_SCRIPTS = [
     '{{ openwisp2_wireguard_path }}/update_wireguard.sh check_config',
 ]
+ALLOWED_SCRIPTS = ["update_wireguard.sh check_config"]
 
+
+file_handler = RotatingFileHandler('{{ openwisp2_wireguard_path }}/log/openwisp-vpnupdater.log', maxBytes=104857600, backupCount=10)
+file_handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s: %(message)s [in %(pathname)s:%(lineno)d]'))
+file_handler.setLevel(logging.INFO)
+app.logger.addHandler(file_handler)
+
+def is_script_allowed(script):
+    return script in ALLOWED_SCRIPTS
 
 def _exec_command(command):
     process = subprocess.Popen(
@@ -20,19 +33,68 @@ def _exec_command(command):
     stdout, stderr = process.communicate()
     exit_code = process.wait(timeout=10)
     if exit_code != 0:
+        app.logger.error("Script execution failed: %s, Error: %s", command, stderr.decode('utf-8'))
         raise subprocess.SubprocessError()
 
 
 @app.route('{{ openwisp2_wireguard_flask_endpoint }}', methods=['POST'])
 def update_vpn_config():
-    if request.args.get('key') != KEY:
+    app.logger.info("Received request to update VPN config")
+    #changed this so we can do input validation and prevent timing hacks
+    provided_key = request.args.get('key')
+    if not provided_key or not safe_str_cmp(provided_key, KEY):
+        #make sure we log attempts to get through with an invalid key.
+        client_info = {
+            'ip_address': request.remote_addr,
+            'user_agent': request.user_agent.string,
+            'requested_url': request.url,
+            'http_method': request.method
+        }
+        app.logger.warning("Authentication failed - invalid or missing key provided. Client info: %s", client_info)
         return Response(status=403)
     for script in UPDATER_SCRIPTS:
         try:
+            #make sure the called scripted is what we expect it to be and if it isn't then exit unauthorized
+            if not is_script_allowed(script):
+                app.logger.error("Unauthorized script access attempt: %s", script)
+                return Response(status=403)
             _exec_command(script)
+            app.logger.info("Script executed successfully: %s", script)
         except subprocess.SubprocessError:
+            app.logger.error("Script execution failed: %s", script)
             return Response(status=500)
     return Response(status=200)
+
+@app.errorhandler(500)
+def handle_500_error(exception):
+    app.logger.error("An internal error occurred: %s", str(exception))
+    return Response(status=500)
+from flask import Flask, Response
+
+@app.after_request
+def set_csp(response):
+    response.headers["Content-Security-Policy"] = "default-src 'self'"
+    return response
+@app.after_request
+def set_x_frame_options(response):
+    response.headers["X-Frame-Options"] = "SAMEORIGIN"
+    return response
+@app.after_request
+def set_x_content_type_options(response):
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    return response
+@app.after_request
+def set_hsts(response):
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    return response
+@app.after_request
+def set_x_xss_protection(response):
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    return response
+@app.after_request
+def set_referrer_policy(response):
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    return response
 
 
 if __name__ == '__main__':

--- a/templates/flask/vpn_updater.py
+++ b/templates/flask/vpn_updater.py
@@ -41,7 +41,6 @@ def _exec_command(command):
 @app.route('{{ openwisp2_wireguard_flask_endpoint }}', methods=['POST'])
 def update_vpn_config():
     app.logger.info("Received request to update VPN config")
-    print("Received request to update VPN config")
     #changed this so we can do input validation and prevent timing hacks
     provided_key = request.args.get('key')
 

--- a/templates/update_scripts/update_wireguard.sh.j2
+++ b/templates/update_scripts/update_wireguard.sh.j2
@@ -59,27 +59,47 @@ log_with_timestamp() {
 
 execute_curl() {
     local url=$1
-    local output
-    output=$($_CURL "$url" 2>&1)  # Capture both stdout and stderr
-    if [ -n "$output" ]; then  # Check if output is not empty
-        log_with_timestamp log_with_timestamp "INFO" "$output"
+    local file_output=$2
+
+    if [ -n "$file_output" ]; then
+        if $_CURL "$url" > "$file_output" 2>&1; then
+            return 0
+        else
+            local exit_code=${PIPESTATUS[0]}
+            log_with_timestamp "ERROR" "curl command failed with exit code $exit_code"
+            return $exit_code
+        fi
+    else
+        if output=$($_CURL "$url" 2>&1); then
+            echo "$output"
+            return 0
+        else
+            local exit_code=$?
+            log_with_timestamp "ERROR" "curl command failed with exit code $exit_code"
+            return $exit_code
+        fi
     fi
-    return ${PIPESTATUS[0]}  # Return the exit status of the curl command
 }
 
 
+
 check_config() {
+    log_with_timestamp "INFO" "Check config called."
     _latest_checksum=$(execute_curl "$_VPN_CHECKSUM_URL")
-    assert_exit_code $LINENO
+    assert_exit_code $? $LINENO
     if [ -f "$_CHECKSUM_FILE" ]; then
+        log_with_timestamp "INFO" "Setting current checksum from $_CHECKSUM_FILE."
         _current_checksum=$(cat $_CHECKSUM_FILE)
     else
+        log_with_timestamp "INFO" "No current checksum."
         _current_checksum=""
     fi
 
     if [ "$_current_checksum" != "$_latest_checksum" ]; then
         log_with_timestamp "INFO" "Configuration changed, downloading new configuration..."
         update_config
+    else
+        log_with_timestamp "INFO" "Configuration has not changed."
     fi
 }
 
@@ -100,12 +120,23 @@ create_new_interface() {
 update_config() {
     umask 0117;
     log_with_timestamp "INFO" "Starting configuration download..."
-    execute_curl "$_VPN_DOWNLOAD_URL" > "$_CONF_TAR"
+    execute_curl "$_VPN_DOWNLOAD_URL" "$_CONF_TAR"
     assert_exit_code $? $LINENO
-    
     log_with_timestamp "INFO" "Configuration downloaded, extracting it..."
-    tar -zxvf $_CONF_TAR -C $CONF_DIR > /dev/null
-    assert_exit_code $? $LINENO
+
+    tar -zxvf $_CONF_TAR -C $CONF_DIR 2>&1 | IFS=$'\n' read -d '' -r -a tar_output
+    exit_code=${PIPESTATUS[0]}
+
+    if [ $exit_code -eq 0 ]; then
+        log_with_timestamp "INFO" "Extracted configuration successfully."
+    else
+        log_with_timestamp "ERROR" "Failed to extract configuration from $_CONF_TAR. Exit code: $exit_code."
+        for line in "${tar_output[@]}"; do
+            log_with_timestamp "ERROR" "$line"
+        done
+    fi
+
+    assert_exit_code $exit_code $LINENO
 
     if [ -e "$_MANAGED_INTERFACE" ]; then
         managed_interface_name=$(cat "$_MANAGED_INTERFACE")
@@ -158,7 +189,7 @@ update_config() {
             log_with_timestamp "ERROR" "Failed to update VXLAN configuration."
         fi
     fi
-
+}
 
 bring_up_interface() {
     for conf_file in $_APPLIED_CONF_DIR/*.conf; do
@@ -173,8 +204,8 @@ bring_up_interface() {
     done
     log_with_timestamp "INFO" "Completed attempting to bring up interfaces."
     exit 0
-}
+    }
 
 
 
-"$@"
+    "$@"

--- a/templates/update_scripts/update_wireguard.sh.j2
+++ b/templates/update_scripts/update_wireguard.sh.j2
@@ -10,7 +10,7 @@ VPN_UUID="{{ openwisp2_wireguard_vpn_uuid }}"
 VPN_KEY="{{ openwisp2_wireguard_vpn_key }}"
 # make sure this directory is writable by the user which calls the script
 CONF_DIR="{{ openwisp2_wireguard_path }}"
-LOGGING_LEVEL="INFO"  # Set this to INFO, ERROR, or DEBUG
+LOGGING_LEVEL="{{ openwisp2_wireguard_update_wireguard_log_level }}"
 
 # do not modify these vars
 _VPN_URL_PATH="$BASE_URL/controller/vpn"
@@ -144,13 +144,21 @@ update_config() {
     # Save checksum of applied configuration
     echo $_latest_checksum > $_CHECKSUM_FILE
 
+    log_with_timestamp "INFO" "Setting VXLAN environment variables."
     export VXLAN_IPV4_METHOD="{{ openwisp2_wireguard_vxlan_ipv4_method }}" \
         VXLAN_IPV6_METHOD="{{ openwisp2_wireguard_vxlan_ipv6_method }}"
+
     if [ -e "$CONF_DIR/vxlan.json" ]; then
-        "$CONF_DIR/update_vxlan.py" "$CONF_DIR/vxlan.json"
-        mv -f "$CONF_DIR/vxlan.json" "$_APPLIED_CONF_DIR/vxlan.json"
+        log_with_timestamp "INFO" "Updating VXLAN configuration using $CONF_DIR/vxlan.json."
+        if "$CONF_DIR/update_vxlan.py" "$CONF_DIR/vxlan.json"; then
+            log_with_timestamp "INFO" "VXLAN configuration updated successfully."
+            mv -f "$CONF_DIR/vxlan.json" "$_APPLIED_CONF_DIR/vxlan.json"
+            log_with_timestamp "INFO" "Moved vxlan.json to $_APPLIED_CONF_DIR."
+        else
+            log_with_timestamp "ERROR" "Failed to update VXLAN configuration."
+        fi
     fi
-}
+
 
 bring_up_interface() {
     for conf_file in $_APPLIED_CONF_DIR/*.conf; do

--- a/templates/update_scripts/update_wireguard.sh.j2
+++ b/templates/update_scripts/update_wireguard.sh.j2
@@ -10,6 +10,7 @@ VPN_UUID="{{ openwisp2_wireguard_vpn_uuid }}"
 VPN_KEY="{{ openwisp2_wireguard_vpn_key }}"
 # make sure this directory is writable by the user which calls the script
 CONF_DIR="{{ openwisp2_wireguard_path }}"
+LOGGING_LEVEL="INFO"  # Set this to INFO, ERROR, or DEBUG
 
 # do not modify these vars
 _VPN_URL_PATH="$BASE_URL/controller/vpn"
@@ -22,20 +23,53 @@ _APPLIED_CONF_DIR="$_WORKING_DIR/current-conf"
 _CONF_TAR="$_WORKING_DIR/conf.tar.gz"
 _CURL="curl -s --show-error --fail {% if openwisp2_wireguard_curl_insecure %}--insecure{% endif %}"
 
+
 mkdir -p $_WORKING_DIR
 mkdir -p $_APPLIED_CONF_DIR
 
 assert_exit_code() {
-    exit_code=$?
-    lineno=$(($1-1))
+    exit_code=$1
+    lineno=$2
     if [ "$exit_code" != "0" ]; then
-        echo "Line $lineno: Command returned non zero exit code: $exit_code"
+        log_with_timestamp "ERROR" "Error at line $lineno: Command returned non-zero exit code: $exit_code"
         exit $exit_code
     fi
 }
 
+log_level_map() {
+    case "$1" in
+        DEBUG) echo 3;;
+        INFO) echo 2;;
+        ERROR) echo 1;;
+        *) echo 0;;
+    esac
+}
+
+log_with_timestamp() {
+    local level=$1
+    local message=$2
+    local log_level_val=$(log_level_map "$level")
+    local current_log_level_val=$(log_level_map "$LOGGING_LEVEL")
+
+    if [ "$log_level_val" -le "$current_log_level_val" ]; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') [$level] - $message"
+    fi
+}
+
+
+execute_curl() {
+    local url=$1
+    local output
+    output=$($_CURL "$url" 2>&1)  # Capture both stdout and stderr
+    if [ -n "$output" ]; then  # Check if output is not empty
+        log_with_timestamp log_with_timestamp "INFO" "$output"
+    fi
+    return ${PIPESTATUS[0]}  # Return the exit status of the curl command
+}
+
+
 check_config() {
-    _latest_checksum=$($_CURL $_VPN_CHECKSUM_URL)
+    _latest_checksum=$(execute_curl "$_VPN_CHECKSUM_URL")
     assert_exit_code $LINENO
     if [ -f "$_CHECKSUM_FILE" ]; then
         _current_checksum=$(cat $_CHECKSUM_FILE)
@@ -44,13 +78,13 @@ check_config() {
     fi
 
     if [ "$_current_checksum" != "$_latest_checksum" ]; then
-        echo "Configuration changed, downloading new configuration..."
+        log_with_timestamp "INFO" "Configuration changed, downloading new configuration..."
         update_config
     fi
 }
 
 clean_old_interface() {
-    echo "Bringing down old wireguard interface $managed_interface_name"
+    log_with_timestamp "INFO" "Bringing down old wireguard interface $managed_interface_name"
     for old_conf_file in $_APPLIED_CONF_DIR/*.conf; do
         [ -e "$old_conf_file" ] || continue
         sudo wg-quick down $old_conf_file
@@ -64,14 +98,15 @@ create_new_interface() {
 }
 
 update_config() {
-    # Set file permissions to 0660, otherwise wg will complain
-    # for having public configurations
     umask 0117;
-    $($_CURL $_VPN_DOWNLOAD_URL > "$_CONF_TAR")
-    assert_exit_code $LINENO
-    echo "Configuration downloaded, extracting it..."
+    log_with_timestamp "INFO" "Starting configuration download..."
+    execute_curl "$_VPN_DOWNLOAD_URL" > "$_CONF_TAR"
+    assert_exit_code $? $LINENO
+    
+    log_with_timestamp "INFO" "Configuration downloaded, extracting it..."
     tar -zxvf $_CONF_TAR -C $CONF_DIR > /dev/null
-    assert_exit_code $LINENO
+    assert_exit_code $? $LINENO
+
     if [ -e "$_MANAGED_INTERFACE" ]; then
         managed_interface_name=$(cat "$_MANAGED_INTERFACE")
     fi
@@ -81,30 +116,31 @@ update_config() {
         filename=$(basename $file)
         interface="${filename%.*}"
 
-        # There is no managed_interface
-        if [ -z ${managed_interface_name+x} ]; then
+        if [ -z "${managed_interface_name+x}" ]; then
+            log_with_timestamp "INFO" "Bringing up new interface $interface..."
             create_new_interface
-        # Current managed interface is not present in new configuration
         elif [ "$managed_interface_name" != "$interface" ]; then
+            log_with_timestamp "INFO" "Cleaning old interface $managed_interface_name..."
             clean_old_interface
-            assert_exit_code $LINENO
+            assert_exit_code $? $LINENO
+            log_with_timestamp "Bringing up new interface $interface..."
             create_new_interface
-            assert_exit_code $LINENO
+            assert_exit_code $? $LINENO
         else
-            # Update the configuration of current managed interface
-            echo "Reloading wireguard interface $interface with config file $file..."
+            log_with_timestamp "INFO" "Reloading wireguard interface $interface with config file $file..."
             wg_conf_filename="$filename-wg"
             sudo wg-quick strip "$CONF_DIR/$filename" > "$CONF_DIR/$wg_conf_filename"
-            assert_exit_code $LINENO
+            assert_exit_code $? $LINENO
             sudo wg syncconf $interface "$CONF_DIR/$wg_conf_filename"
-            assert_exit_code $LINENO
+            assert_exit_code $? $LINENO
             rm "$CONF_DIR/$wg_conf_filename"
         fi
         echo "$interface" > "$_MANAGED_INTERFACE"
         mv -f "$file" "$_APPLIED_CONF_DIR/$filename"
-        assert_exit_code $LINENO
+        assert_exit_code $? $LINENO
     done
 
+    log_with_timestamp "INFO" "Configuration update completed."
     # Save checksum of applied configuration
     echo $_latest_checksum > $_CHECKSUM_FILE
 
@@ -119,9 +155,18 @@ update_config() {
 bring_up_interface() {
     for conf_file in $_APPLIED_CONF_DIR/*.conf; do
         [ -e "$conf_file" ] || continue
-        sudo wg-quick up $conf_file || true
+
+        log_with_timestamp "INFO" "Attempting to bring up interface with config: $conf_file"
+        if sudo wg-quick up $conf_file 2>&1 | log_with_timestamp "INFO"; then
+            log_with_timestamp "INFO" "Successfully brought up interface with config: $conf_file"
+        else
+            log_with_timestamp "ERROR" "Failed to bring up interface with config: $conf_file"
+        fi
     done
+    log_with_timestamp "INFO" "Completed attempting to bring up interfaces."
     exit 0
 }
+
+
 
 "$@"


### PR DESCRIPTION
https://github.com/openwisp/ansible-wireguard-openwisp/issues/36#issue-1993057312

Added all requirements to address the comments I made.  Two problems right now that seem to be Flask problems even in the current master.   I know your comments - please look at what I did and if you still think uswgi is more appropriate I'll relook at the options there.

1.  Some tests fail this is the same in my changes and the current master when running tests:

fatal: [openwisp2-ubuntu1804]: FAILED! => changed=false 
  attempts: 5
  cache_update_time: 1700166166
  cache_updated: false
  msg: |-
    '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"       install 'acl=2.2.52-3build1'' failed: E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
  rc: 100
  stderr: |-
    E: Unmet dependencies. Try 'apt --fix-broken install' with no packages (or specify a solution).
  stderr_lines: <omitted>
  stdout: |-
    Reading package lists...
    Building dependency tree...
    Reading state information...
    You might want to run 'apt --fix-broken install' to correct these.
    The following packages have unmet dependencies:
     network-manager : Depends: policykit-1 but it is not going to be installed

fatal: [openwisp2-centos8]: FAILED! => changed=false 
  attempts: 5
  failures: []
  msg: |-
    Depsolve Error occurred:
     Problem: cannot install the best candidate for the job
      - nothing provides kernel(__x86_return_thunk) = 0x5b8239ca needed by kmod-wireguard-8:1.0.20220627-5.el8_8.elrepo.x86_64
      - nothing provides kernel >= 4.18.0-477.10.1.el8_8 needed by kmod-wireguard-8:1.0.20220627-5.el8_8.elrepo.x86_64
      - nothing provides kernel(netif_napi_add_weight) = 0x7d07a228 needed by kmod-wireguard-8:1.0.20220627-5.el8_8.elrepo.x86_64
      - nothing provides kernel(__icmp_send) = 0xbabee2d4 needed by kmod-wireguard-8:1.0.20220627-5.el8_8.elrepo.x86_64
      - nothing provides kernel(__skb_flow_dissect) = 0x73874cd8 needed by kmod-wireguard-8:1.0.20220627-5.el8_8.elrepo.x86_64
      - nothing provides kernel(flow_keys_basic_dissector) = 0x97f22f58 needed by kmod-wireguard-8:1.0.20220627-5.el8_8.elrepo.x86_64
  rc: 1
  results: []


fatal: [openwisp2-centos7]: FAILED! => changed=false 
  cmd:
  - modprobe
  - wireguard
  delta: '0:00:00.056162'
  end: '2023-11-16 20:27:40.375216'
  msg: non-zero return code
  rc: 1
  start: '2023-11-16 20:27:40.319054'
  stderr: ''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>

fatal: [openwisp2-centos8]: FAILED! => changed=false 
  cmd:
  - modprobe
  - wireguard
  delta: '0:00:00.006907'
  end: '2023-11-16 20:27:40.345629'
  msg: non-zero return code
  rc: 1
  start: '2023-11-16 20:27:40.338722'
  stderr: 'modprobe: FATAL: Module wireguard not found in directory /lib/modules/6.2.0-36-generic'
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
fatal: [openwisp2-debian10]: FAILED! => changed=false 
  cmd: /bin/systemctl
  msg: 'Failed to connect to bus: No such file or directory'
  rc: 1
  stderr: |-
    Failed to connect to bus: No such file or directory
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
fatal: [openwisp2-ubuntu2004]: FAILED! => changed=false 
  cmd: /usr/bin/systemctl
  msg: 'Failed to connect to bus: No such file or directory'
  rc: 1
  stderr: |-
    Failed to connect to bus: No such file or directory
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
fatal: [openwisp2-ubuntu1804]: FAILED! => changed=false 
  cmd: /bin/systemctl
  msg: 'Failed to connect to bus: No such file or directory'
  rc: 1
  stderr: |-
    Failed to connect to bus: No such file or directory
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>

2. for some reason Flask is collecting werkzeug-3.0.1 which is not compatible with Flask~=2.0.3.  I know how to correct this in the server but I don't know the right way to fix this in ansible.

        "Collecting Flask~=2.0.3",
        "  Downloading Flask-2.0.3-py3-none-any.whl (95 kB)",
        "     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 95.6/95.6 kB 2.9 MB/s eta 0:00:00",
        "Collecting uwsgi~=2.0.19",
        "  Downloading uwsgi-2.0.23.tar.gz (810 kB)",
        "     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 810.3/810.3 kB 21.5 MB/s eta 0:00:00",
        "  Preparing metadata (setup.py): started",
        "  Preparing metadata (setup.py): finished with status 'done'",
        "Collecting Werkzeug>=2.0 (from Flask~=2.0.3)",
        "  Downloading werkzeug-3.0.1-py3-none-any.whl.metadata (4.1 kB)",
