### PR TITLE
[fix] Upgrade packaging library

### DIFF
--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -8,6 +8,7 @@
       - wheel
       - attrs
       - importlib-metadata
+      - packaging
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_wireguard_python }}"


### PR DESCRIPTION
Fixes:
TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
