### PR TITLE
Issues/52 python dependencies to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+setuptools
+wheel
+attrs
+importlib-metadata
+packaging
+Flask~=3.0.3
+Werkzeug~=3.0.3
+uwsgi~=2.0.26

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -1,14 +1,7 @@
 ---
-
 - name: Update pip & related tools
   pip:
-    name:
-      - pip
-      - setuptools
-      - wheel
-      - attrs
-      - importlib-metadata
-      - packaging
+    name: pip
     state: latest
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_wireguard_python }}"
@@ -20,13 +13,14 @@
   until: result is success
   notify: reload supervisor
 
-- name: Install Flask, Werkzeug and uWSGI
+- name: Read local requirements.txt
+  local_action: command cat /path/to/requirements.txt
+  register: requirements
+
+- name: Install Python modules from requirements.txt
   pip:
-    name:
-      - "Flask~=3.0.3"
-      - "uwsgi~=2.0.26"
-      - "Werkzeug~=3.0.3"
-    state: latest
+    name: "{{ requirements.stdout_lines }}"
+    state: present
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_wireguard_python }}"
     virtualenv_site_packages: true


### PR DESCRIPTION
## Checklist

- [x] I have read the [[OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html)](http://openwisp.io/docs/developer/contributing.html).
- [x] I have tested the changes in this pull request to make sure they work.
- [ ] I have added or updated tests for any new or changed code.
- [ ] I have updated the documentation where needed.

---

## Reference to Existing Issue

Closes #52.

---

## Description of Changes

This pull request moves Python dependencies from `pip.yml` to a `requirements.txt` file for easier management. Here’s what was done:

1. **Created a `requirements.txt` file**:
   - Added all dependencies, such as `Flask`, `Werkzeug`, and `uwsgi`, into this file to keep things organized.

2. **Updated `pip.yml`**:
   - Adjusted the Ansible tasks to install dependencies from `requirements.txt` instead of listing them directly in the file.
   - Added steps to:
     - Update `pip` and related tools like `setuptools` and `wheel`.
     - Install dependencies in a virtual environment using the `requirements.txt` file.

3. **Dependabot Integration**:
   - Made sure tools like Dependabot can track and update dependencies in `requirements.txt` automatically.

4. **Tested the Changes**:
   - Ran the updated playbook to confirm everything works as expected.

These changes make it easier to manage and update dependencies while keeping the setup clean and consistent.