### PR TITLE
handlers: restart only the wireguard vpn updater supervisor process (fixes #47)

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,10 @@
 ---
-- name: reload supervisor
-  command: supervisorctl reload
+- name: restart wireguard vpn updater
+  command: "supervisorctl restart openwisp-flask-vpn-updater-{{ openwisp2_wireguard_vpn_uuid }}"
+  register: supervisor_restart
+  failed_when: >
+    supervisor_restart.rc != 0 and
+    'ERROR (no such process)' not in supervisor_restart.stderr
+  changed_when: >
+    supervisor_restart.rc == 0 and
+    'ERROR (no such process)' not in supervisor_restart.stderr

--- a/tasks/flask.yml
+++ b/tasks/flask.yml
@@ -14,7 +14,7 @@
     group: "{{ openwisp_group }}"
     mode: 0750
   tags: [wireguard, updater_script]
-  notify: reload supervisor
+  notify: restart wireguard vpn updater
 
 - name: Bring up WireGuard interface on boot
   block:
@@ -63,7 +63,7 @@
     mode: 0750
     group: "{{ openwisp_group }}"
   tags: [wireguard, updater_script]
-  notify: reload supervisor
+  notify: restart wireguard vpn updater
 
 - name: Add wireguard_update.sh script to cron
   cron:
@@ -79,7 +79,7 @@
   tags: [wireguard, updater_script]
 
 - name: Deploy VPN updater flask app
-  notify: reload supervisor
+  notify: restart wireguard vpn updater
   template:
     src: flask/vpn_updater.py
     dest: "{{ openwisp2_wireguard_path }}/vpn_updater.py"
@@ -98,5 +98,5 @@
     src: supervisor/vpn_updater.j2
     dest: "{{ supervisor_conf_path }}/flask_vpn_updater_{{ openwisp2_wireguard_vpn_uuid }}.{{ supervisord_conf_extension }}"
     mode: 0744
-  notify: reload supervisor
+  notify: restart wireguard vpn updater
   tags: [flask]

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -17,7 +17,7 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: restart wireguard vpn updater
 
 - name: Copy requirements.txt
   copy:
@@ -31,7 +31,7 @@
     virtualenv_python: "{{ openwisp2_wireguard_python }}"
     virtualenv_site_packages: true
     virtualenv_command: "{{ openwisp2_wireguard_virtualenv_command }}"
-  notify: reload supervisor
+  notify: restart wireguard vpn updater
   retries: 5
   delay: 10
   register: result

--- a/tasks/uwsgi.yml
+++ b/tasks/uwsgi.yml
@@ -55,9 +55,8 @@
         - certbot_check.rc == 0
         - certbot_check.stdout != ""
   tags: [ssl]
-
 - name: uwsgi.ini
-  notify: reload supervisor
+  notify: restart wireguard vpn updater
   template:
     src: flask/uwsgi.ini
     dest: "{{ openwisp2_wireguard_path }}/uwsgi.ini"


### PR DESCRIPTION
## Summary
This PR improves deployment reliability by stopping Supervisor from restarting unrelated processes.
Replaces the global `supervisorctl reload` handler with a targeted restart of the WireGuard VPN updater supervisor process to avoid unnecessary restarts of unrelated services.

## What was changed

- Added a new handler in `handlers/main.yml`:
  - Runs: `supervisorctl restart openwisp-flask-vpn-updater-{{ openwisp2_wireguard_vpn_uuid }}`
  - Uses `register`, `failed_when`, and `changed_when` logic so:
    - The play **does not fail** if the process doesn't exist
    - The task reports **changed** only when a restart succeeds
- Updated `notify` statements in tasks to use the new handler:
  - `tasks/flask.yml`
  - `tasks/pip.yml`
  - `tasks/uwsgi.yml`
- Kept `verify.yml` unchanged to avoid altering test behavior unnecessarily

## Why

Reloading supervisor triggers a restart of **all managed processes**, creating avoidable downtime.  
Restarting only the affected process is safer, more efficient, and aligns with the request in **issue #47**.

## How to verify

Run local QA checks:

```bash
run-qa-checks
```
(Already tested locally, passed successfully)

Closes #47

Happy to update the PR if needed. Thanks for reviewing!

