### PR TITLE
[chores:qa] Moved lint checks to run-qa-checks and fixed all linting issues

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,6 @@
 ---
 
 skip_list:
-  - '303'   # Using command rather than module
-  - '403'   # Package installs should not use latest
-  - '106'   # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern'
+  - command-instead-of-module  # Using command rather than module
+  - package-latest  # Package installs should not use latest
+  - role-name  # Role name does not match pattern

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,16 @@
+---
 # These are supported funding model platforms
 
 github: [openwisp]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
+patreon:  # Replace with a single Patreon username
+open_collective:  # Replace with a single Open Collective username
+ko_fi:  # Replace with a single Ko-fi username
+tidelift:  # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge:  # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay:  # Replace with a single Liberapay username
+issuehunt:  # Replace with a single IssueHunt username
+lfx_crowdfunding:  # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar:  # Replace with a single Polar username
+buy_me_a_coffee:  # Replace with a single Buy Me a Coffee username
+thanks_dev:  # Replace with a single thanks.dev username
 custom: ["https://openwisp.org/sponsorship/"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,15 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "pip" # Check for Python package updates
-    directory: "/" # The root directory where the Ansible role is located
+  - package-ecosystem: "pip"  # Check for Python package updates
+    directory: "/"  # The root directory where the Ansible role is located
     schedule:
-      interval: "monthly" # Check for updates weekly
+      interval: "monthly"  # Check for updates monthly
     commit-message:
       prefix: "[deps] "
-  - package-ecosystem: "github-actions" # Check for GitHub Actions updates
-    directory: "/" # The root directory where the Ansible role is located
+  - package-ecosystem: "github-actions"  # Check for GitHub Actions updates
+    directory: "/"  # The root directory where the Ansible role is located
     schedule:
-      interval: "monthly" # Check for updates weekly
+      interval: "monthly"  # Check for updates monthly
     commit-message:
       prefix: "[ci] "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: Ansible WireGuard OpenWISP CI Build
 
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
@@ -38,6 +38,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install python dependencies
+        id: deps
         run: |
           pip install -U pip wheel setuptools
           pip install -r requirements-test.txt
@@ -46,10 +47,12 @@ jobs:
         run: ansible-galaxy collection install "community.general:>=3.6.0"
 
       - name: QA checks
+        continue-on-error: true
         run: |
           ./run-qa-checks
 
       - name: Tests
+        if: ${{ !cancelled() && steps.deps.conclusion == 'success' }}
         run: molecule test
         env:
           ROLE_NAME: openwisp2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 ---
 name: Ansible WireGuard OpenWISP Publish Release
 
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   release:
     types:
       - published

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 # Code editor
 .vscode/
 
+.ansible/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,3 +4,11 @@ rules:
   line-length:
     max: 160
     level: warning
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
-- name: reload supervisor
-  command: supervisorctl reload
+- name: Reload supervisor
+  ansible.builtin.command: supervisorctl reload
+  changed_when: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,10 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  yamllint . || true
-  ansible-lint || true
 platforms:
   - name: "${ROLE_NAME:-instance}-${MOLECULE_DISTRO}"
     image: "geerlingguy/docker-${MOLECULE_DISTRO}-ansible:${tag:-latest}"

--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -1,10 +1,6 @@
 ---
 driver:
   name: docker
-lint: |
-  set -e
-  yamllint . || true
-  ansible-lint || true
 platforms:
   - name: "openwisp2-ubuntu2004"
     image: "geerlingguy/docker-ubuntu2004-ansible:latest"

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -13,22 +13,25 @@
     # since the update_wireguard.sh will try to download VPN configuration f
     # rom OpenWISP which is not present here.
     - name: Copy update_wireguard.sh
-      copy:
+      ansible.builtin.copy:
         content: |
           #!/bin/bash
           exit 0
         dest: "{{ openwisp2_wireguard_path }}/update_wireguard.sh"
         group: "{{ openwisp_group }}"
-        mode: 0750
+        mode: "0750"
       tags: [wireguard, updater_script]
-    - name: reload supervisor
-      command: supervisorctl reload
+    - name: Reload supervisor
+      ansible.builtin.command: supervisorctl reload
+      changed_when: true
   tasks:
     - name: Test Flask WireGuard Updater
       block:
         - name: Test with correct auth token
-          uri:
-            url: "https://{{ inventory_hostname }}:{{ openwisp2_wireguard_flask_port }}{{ openwisp2_wireguard_flask_endpoint }}?key={{ openwisp2_wireguard_flask_key }}"
+          ansible.builtin.uri:
+            url: >-
+              https://{{ inventory_hostname }}:{{ openwisp2_wireguard_flask_port
+              }}{{ openwisp2_wireguard_flask_endpoint }}?key={{ openwisp2_wireguard_flask_key }}
             validate_certs: false
             method: "POST"
             status_code: [200]
@@ -37,17 +40,20 @@
           retries: 5
           delay: 5
         - name: Test with wrong auth token
-          uri:
-            url: "https://{{ inventory_hostname }}:{{ openwisp2_wireguard_flask_port }}{{ openwisp2_wireguard_flask_endpoint }}?key=wrong-auth-token"
+          ansible.builtin.uri:
+            url: >-
+              https://{{ inventory_hostname }}:{{ openwisp2_wireguard_flask_port
+              }}{{ openwisp2_wireguard_flask_endpoint }}?key=wrong-auth-token
             validate_certs: false
             method: "POST"
             status_code: [403]
       rescue:
         - name: Get Flask log
-          command: "tail -n 500 {{ openwisp2_wireguard_path }}/vpn_updater.log"
+          ansible.builtin.command: "tail -n 500 {{ openwisp2_wireguard_path }}/vpn_updater.log"
           register: flask_log
+          changed_when: false
 
         - name: Show Flask log
-          debug:
+          ansible.builtin.debug:
             var: flask_log
           failed_when: true

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -2,5 +2,8 @@
 
 set -e
 
+yamllint .
+ansible-lint
+
 openwisp-qa-check \
   --skip-checkmigrations

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -1,6 +1,6 @@
 ---
 - name: "[Debian/Ubuntu] Update APT package cache"
-  apt:
+  ansible.builtin.apt:
     update_cache: true
   changed_when: false
   retries: 5
@@ -9,14 +9,14 @@
   until: result is success
 
 - name: "[Debian] Enable backports repository"
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main"
     state: present
     update_cache: true
   when: ansible_distribution == 'Debian' and ansible_distribution_major_version | int < 11
 
 - name: "[Debian/Ubuntu] Install system packages"
-  apt:
+  ansible.builtin.apt:
     name:
       - supervisor
       - openssl
@@ -37,7 +37,8 @@
   until: result is success
 
 - name: "[Debian/Ubuntu] Install acl if acting as non-root user"
-  apt: name=acl
+  ansible.builtin.apt:
+    name: acl
   when: ansible_user is not defined or ansible_user != 'root'
   retries: 5
   delay: 10
@@ -46,13 +47,13 @@
   ignore_errors: true
 
 - name: "[Debian/Ubuntu] Ensure supervisor is started"
-  service:
+  ansible.builtin.service:
     name: supervisor
     state: started
     enabled: true
 
 - name: "[Debian/Ubuntu] Install python3 packages"
-  apt:
+  ansible.builtin.apt:
     name:
       - python3-pip
       - python3-dev
@@ -65,15 +66,15 @@
 - name: "[Debian/Ubuntu] Check virtualenv"
   block:
     - name: "[Debian/Ubuntu] Check virtualenv executable path"
-      command: which virtualenv
+      ansible.builtin.command: which virtualenv
       register: virtualenv_output
       changed_when: false
     - name: "[Debian/Ubuntu] Test virtualenv executable path not empty"
-      fail:
+      ansible.builtin.fail:
       when: virtualenv_output | length == 0
       changed_when: false
   rescue:
     - name: Install virtualenv system package
-      apt:
+      ansible.builtin.apt:
         name: virtualenv
         state: latest

--- a/tasks/complete.yml
+++ b/tasks/complete.yml
@@ -2,7 +2,8 @@
 - name: Run update_wireguard.sh check_config as openwisp user
   become: true
   become_user: openwisp
-  command: "{{ openwisp2_wireguard_path }}/update_wireguard.sh check_config"
+  ansible.builtin.command: "{{ openwisp2_wireguard_path }}/update_wireguard.sh check_config"
+  changed_when: true
   # Skip this task during molecule tests: the OpenWISP Controller is not available
   # inside the test container, so update_wireguard.sh would fail when attempting
   # to download VPN configuration.
@@ -10,7 +11,7 @@
     - molecule-notest
 
 - name: Show webhook endpoint and webook auth token to use in OpenWISP
-  debug:
+  ansible.builtin.debug:
     msg:
       - "Set the following parametrers in {{ openwisp2_wireguard_controller_url }}/admin/config/vpn/{{ openwisp2_wireguard_vpn_uuid }}/change/"
       - "Webhook Endpoint: https://{{ inventory_hostname }}:{{ openwisp2_wireguard_flask_port }}{{ openwisp2_wireguard_flask_endpoint }}"

--- a/tasks/flask.yml
+++ b/tasks/flask.yml
@@ -1,72 +1,72 @@
 ---
 - name: Create Wireguard directory
-  file:
+  ansible.builtin.file:
     path: "{{ openwisp2_wireguard_path }}"
     state: directory
     group: "{{ openwisp_group }}"
-    mode: 0770
+    mode: "0770"
   tags: [wireguard]
 
-- name: update_wireguard.sh
-  template:
+- name: Deploy update_wireguard.sh
+  ansible.builtin.template:
     src: update_scripts/update_wireguard.sh.j2
     dest: "{{ openwisp2_wireguard_path }}/update_wireguard.sh"
     group: "{{ openwisp_group }}"
-    mode: 0750
+    mode: "0750"
   tags: [wireguard, updater_script]
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Bring up WireGuard interface on boot
+  tags: [wireguard]
   block:
     - name: "Create rc-wg.service"
-      template:
+      ansible.builtin.template:
         src: rc-wg/rc-wg.service
         dest: /etc/systemd/system/rc-wg.service
-        mode: 0755
+        mode: "0755"
     - name: "Create /etc/rc.d"
-      file:
+      ansible.builtin.file:
         path: /etc/rc.d
         state: directory
         group: "{{ openwisp_group }}"
-        mode: 0755
+        mode: "0755"
     - name: "Create rc-wg.local"
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: /etc/rc.d/rc-wg.local
         state: present
         create: true
         line: "#!/bin/bash"
         insertbefore: BOF
-        mode: 0755
+        mode: "0755"
         group: "{{ openwisp_group }}"
     - name: Add WireGuard interface bring up command
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: /etc/rc.d/rc-wg.local
         state: present
         create: true
         line: "{{ openwisp2_wireguard_path }}/update_wireguard.sh bring_up_interface # {{ openwisp2_wireguard_vpn_uuid }}"
-        mode: 0755
+        mode: "0755"
         group: "{{ openwisp_group }}"
-    - name: systemctl daemon-reload
-      command: systemctl daemon-reload
+    - name: Systemctl daemon-reload
+      ansible.builtin.command: systemctl daemon-reload
       changed_when: false
     - name: Enable rc-wg service
-      service:
+      ansible.builtin.service:
         name: rc-wg
         enabled: true
         state: started
-  tags: [wireguard]
 
-- name: update_vxlan.py
+- name: Deploy update_vxlan.py
   ansible.builtin.copy:
     src: update_scripts/update_vxlan.py
     dest: "{{ openwisp2_wireguard_path }}/update_vxlan.py"
-    mode: 0750
+    mode: "0750"
     group: "{{ openwisp_group }}"
   tags: [wireguard, updater_script]
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Add wireguard_update.sh script to cron
-  cron:
+  ansible.builtin.cron:
     name: Run update wireguard periodically {{ openwisp2_wireguard_vpn_uuid }}
     minute: "{{ openwisp2_wireguard_crontab.minute }}"
     hour: "{{ openwisp2_wireguard_crontab.hour }}"
@@ -79,24 +79,24 @@
   tags: [wireguard, updater_script]
 
 - name: Deploy VPN updater flask app
-  notify: reload supervisor
-  template:
+  notify: Reload supervisor
+  ansible.builtin.template:
     src: flask/vpn_updater.py
     dest: "{{ openwisp2_wireguard_path }}/vpn_updater.py"
     group: "{{ openwisp_group }}"
-    mode: 0754
+    mode: "0754"
   tags: [flask]
 
 - name: "[Ubuntu/Debian] Set extension and path for supervisor configuration"
-  set_fact:
+  ansible.builtin.set_fact:
     supervisord_conf_extension: "conf"
     supervisor_conf_path: "/etc/supervisor/conf.d"
   when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
 
 - name: Supervisor flask config
-  template:
+  ansible.builtin.template:
     src: supervisor/vpn_updater.j2
     dest: "{{ supervisor_conf_path }}/flask_vpn_updater_{{ openwisp2_wireguard_vpn_uuid }}.{{ supervisord_conf_extension }}"
-    mode: 0744
-  notify: reload supervisor
+    mode: "0744"
+  notify: Reload supervisor
   tags: [flask]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,24 +1,31 @@
 ---
 - name: Check required variables
-  fail: msg="Variable '{{ item }}' is not defined"
+  ansible.builtin.fail:
+    msg: "Variable '{{ item }}' is not defined"
   when: item is false
   with_items: "{{ openwisp2_wireguard_required_variables }}"
 
-- import_tasks: user_management.yml
+- name: Import user management tasks
+  ansible.builtin.import_tasks: user_management.yml
   tags: [wireguard_openwisp, user_management]
 
-- import_tasks: apt.yml
+- name: Import APT tasks
+  ansible.builtin.import_tasks: apt.yml
   when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
   tags: [wireguard_openwisp, apt]
 
-- import_tasks: pip.yml
+- name: Import pip tasks
+  ansible.builtin.import_tasks: pip.yml
   tags: [wireguard_openwisp, pip]
 
-- import_tasks: flask.yml
+- name: Import flask tasks
+  ansible.builtin.import_tasks: flask.yml
   tags: [wireguard_openwisp, flask]
 
-- import_tasks: uwsgi.yml
+- name: Import uwsgi tasks
+  ansible.builtin.import_tasks: uwsgi.yml
   tags: [wireguard_openwisp, uwsgi]
 
-- import_tasks: complete.yml
+- name: Import complete tasks
+  ansible.builtin.import_tasks: complete.yml
   tags: [wireguard_openwisp, complete]

--- a/tasks/pip.yml
+++ b/tasks/pip.yml
@@ -1,6 +1,6 @@
 ---
 - name: Update pip & related tools
-  pip:
+  ansible.builtin.pip:
     name:
       - pip
       - setuptools
@@ -17,21 +17,22 @@
   delay: 10
   register: result
   until: result is success
-  notify: reload supervisor
+  notify: Reload supervisor
 
 - name: Copy requirements.txt
-  copy:
+  ansible.builtin.copy:
     src: requirements.txt
     dest: "{{ openwisp2_wireguard_path }}/requirements.txt"
+    mode: "0644"
 
 - name: Install Python dependencies
-  pip:
+  ansible.builtin.pip:
     requirements: "{{ openwisp2_wireguard_path }}/requirements.txt"
     virtualenv: "{{ virtualenv_path }}"
     virtualenv_python: "{{ openwisp2_wireguard_python }}"
     virtualenv_site_packages: true
     virtualenv_command: "{{ openwisp2_wireguard_virtualenv_command }}"
-  notify: reload supervisor
+  notify: Reload supervisor
   retries: 5
   delay: 10
   register: result

--- a/tasks/user_management.yml
+++ b/tasks/user_management.yml
@@ -1,11 +1,11 @@
 ---
-- name: Create "{{ openwisp_group }}" group
-  group:
+- name: Create openwisp group {{ openwisp_group }}
+  ansible.builtin.group:
     name: "{{ openwisp_group }}"
     state: present
 
-- name: Create "{{ openwisp_user }}" user
-  user:
+- name: Create openwisp user {{ openwisp_user }}
+  ansible.builtin.user:
     name: "{{ openwisp_user }}"
     shell: /sbin/nologin
     state: present
@@ -15,4 +15,4 @@
   ansible.builtin.copy:
     src: "sudoers.d/{{ openwisp_group }}"
     dest: /etc/sudoers.d/openwisp
-    mode: 0440
+    mode: "0440"

--- a/tasks/uwsgi.yml
+++ b/tasks/uwsgi.yml
@@ -1,39 +1,42 @@
 ---
-- name: Create "{{ openwisp2_wireguard_path }}/ssl"
-  file:
+- name: Create SSL directory
+  ansible.builtin.file:
     path: "{{ openwisp2_wireguard_path }}/ssl"
     state: directory
-    mode: 0770
+    mode: "0770"
     group: "{{ openwisp_group }}"
   tags: [ssl]
 
 - name: Create SSL cert if not exists yet
   become: true
   become_user: root
-  command: >
-    openssl req -new -nodes -x509 \
-    -subj "/C={{ openwisp2_wireguard_ssl_country }}/ST={{ openwisp2_wireguard_ssl_state }} \
-           /L={{ openwisp2_wireguard_ssl_locality }}/O={{ openwisp2_wireguard_ssl_organization }} \
-           /CN={{ openwisp2_wireguard_ssl_common_name }}" \
-    -days 3650 \
-    -keyout {{ openwisp2_wireguard_ssl_key }} \
-    -out {{ openwisp2_wireguard_ssl_cert }} \
-    -extensions v3_ca creates={{ openwisp2_wireguard_ssl_cert }}
+  ansible.builtin.command:
+    cmd: >
+      openssl req -new -nodes -x509
+      -subj "/C={{ openwisp2_wireguard_ssl_country }}/ST={{ openwisp2_wireguard_ssl_state }}
+             /L={{ openwisp2_wireguard_ssl_locality }}/O={{ openwisp2_wireguard_ssl_organization }}
+             /CN={{ openwisp2_wireguard_ssl_common_name }}"
+      -days 3650
+      -keyout {{ openwisp2_wireguard_ssl_key }}
+      -out {{ openwisp2_wireguard_ssl_cert }}
+      -extensions v3_ca
+    creates: "{{ openwisp2_wireguard_ssl_cert }}"
   tags: [ssl]
 
 - name: Add renewal hook for certbot
   when:
     - openwisp2_wireguard_ssl_cert is defined
     - '"etc/letsencrypt/live/" in openwisp2_wireguard_ssl_cert'
+  tags: [ssl]
   block:
     - name: Check if certbot is installed
-      command: which certbot
+      ansible.builtin.command: which certbot
       register: certbot_check
       changed_when: false
       failed_when: false
-      check_mode: no
+      check_mode: false
     - name: Ensure certbot renewal post hook directory exists
-      file:
+      ansible.builtin.file:
         path: /etc/letsencrypt/renewal-hooks/post
         state: directory
         owner: root
@@ -43,7 +46,7 @@
         - certbot_check.rc == 0
         - certbot_check.stdout != ""
     - name: Create renewal hook to restart uwsgi
-      copy:
+      ansible.builtin.copy:
         dest: /etc/letsencrypt/renewal-hooks/post/restart-openwisp-flask-vpn-updater-{{ openwisp2_wireguard_vpn_uuid }}.sh
         content: |
           #!/bin/bash
@@ -54,13 +57,12 @@
       when:
         - certbot_check.rc == 0
         - certbot_check.stdout != ""
-  tags: [ssl]
 
-- name: uwsgi.ini
-  notify: reload supervisor
-  template:
+- name: Deploy uwsgi.ini
+  notify: Reload supervisor
+  ansible.builtin.template:
     src: flask/uwsgi.ini
     dest: "{{ openwisp2_wireguard_path }}/uwsgi.ini"
     group: "{{ openwisp_group }}"
-    mode: 0644
+    mode: "0644"
   tags: [flask]


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #51

## Description of Changes

- Removed 'lint' section with '|| true' from molecule/default/molecule.yml
  and molecule/local/molecule.yml that silently ignored lint failures
- Added yamllint and ansible-lint to run-qa-checks script
- Updated CI workflow: added continue-on-error for QA checks so
  failing QA does not prevent tests from running
- Updated .yamllint.yml to comply with ansible-lint requirements
- Updated .ansible-lint to use modern named rules instead of
  deprecated numeric codes
- Fixed all 96 ansible-lint violations across task files:
  - Used FQCN for all builtin modules (ansible.builtin.*)
  - Fixed no-free-form syntax issues
  - Fixed name[casing] (capitalized task/handler names)
  - Added names to all import_tasks (name[missing])
  - Fixed name[template] (Jinja templates only at end of name)
  - Fixed key-order[task] issues
  - Added changed_when to command tasks (no-changed-when)
  - Added mode to copy task (risky-file-permissions)
  - Fixed yaml[truthy] (check_mode: no -> false)
  - Quoted octal mode values (yaml[octal-values])
  - Fixed yaml[line-length] in verify.yml
- Fixed yamllint issues in .github/FUNDING.yml and .github/dependabot.yml
  (document-start, comment spacing)
- Fixed comment spacing in CI workflow files
- Added .ansible/ to .gitignore
